### PR TITLE
fix(cli): correct script entry point to use cli_main function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 dev = []
 
 [project.scripts]
-cpack = "coldpack.cli:main"
+cpack = "coldpack.cli:cli_main"
 
 [project.urls]
 Homepage = "https://github.com/rxchi1d/coldpack"


### PR DESCRIPTION
## Summary
- Fixed CLI entry point configuration in pyproject.toml
- Changed from `coldpack.cli:main` to `coldpack.cli:cli_main`
- Resolves issue where `cpack --help` showed no output when installed externally

## Problem
The `cpack` command was not working when installed via `uv add coldpack` or `pip install coldpack`. Running `cpack --help` produced no output due to incorrect entry point configuration.

## Solution
The entry point was pointing to the wrong function. The `main` function in `cli.py` is a Typer callback, while `cli_main` is the actual CLI entry point that should be called when the `cpack` command is executed.

## Test plan
- [x] Local testing with `uv run python -m coldpack.cli --help` works correctly
- [x] Shows all available commands (archive, extract, verify, repair, info, formats)
- [x] After this fix is released, external installations should work properly

## Breaking Changes
None - this is a bug fix that restores intended functionality.