### PR TITLE
fix(ci): add full PEP 440 pre-release support to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to build (e.g., v0.1.0, v0.1.0a1, v0.2.0.dev1)'
+        description: 'Tag to build (e.g., v0.1.0, v0.1.0a1, v0.1.0b1, v0.1.0rc1, v0.2.0.dev1)'
         required: true
         type: string
 
@@ -75,12 +75,12 @@ jobs:
         echo "Git tag: $TAG"
 
         # Validate tag format (PEP 440 compliant)
-        if [[ $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+|a[0-9]+)?$ ]]; then
+        if [[ $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+)?$ ]]; then
           echo "✓ Tag format is valid: $TAG"
         else
           echo "✗ Invalid tag format: $TAG"
-          echo "Expected format: v{major}.{minor}.{patch}[.dev{N}|a{N}]"
-          echo "Examples: v1.0.0, v1.0.0a1, v1.0.0.dev1"
+          echo "Expected format: v{major}.{minor}.{patch}[.dev{N}|a{N}|b{N}|rc{N}]"
+          echo "Examples: v1.0.0, v1.0.0a1, v1.0.0b1, v1.0.0rc1, v1.0.0.dev1"
           exit 1
         fi
 
@@ -105,7 +105,7 @@ jobs:
         fi
 
         # Verify version format is PEP 440 compliant
-        if [[ $GENERATED_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+|a[0-9]+)?$ ]]; then
+        if [[ $GENERATED_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+)?$ ]]; then
           echo "✓ Generated version is PEP 440 compliant: $GENERATED_VERSION"
         else
           echo "✗ Generated version is not PEP 440 compliant: $GENERATED_VERSION"


### PR DESCRIPTION
## Summary
- Fix build workflow tag validation to fully support PEP 440 pre-release formats
- Resolve the issue where beta tags like `v0.1.0b1` could not pass validation
- Add support for release candidate (rc) formats

## Changes
- Update regex pattern to include `b[0-9]+` and `rc[0-9]+` formats
- Add beta and rc examples in error messages and documentation
- Ensure consistency across all validation steps

## Supported Formats
The following complete PEP 440 version formats are now supported:
- **Stable**: `v1.0.0`
- **Alpha**: `v1.0.0a1`  
- **Beta**: `v1.0.0b1` ✅ (newly supported)
- **Release Candidate**: `v1.0.0rc1` ✅ (newly supported)
- **Development**: `v1.0.0.dev1`

## Test plan
- [ ] Verify that the `v0.1.0b1` tag can pass workflow validation
- [ ] Ensure other pre-release formats still work as expected
- [ ] Test manual triggering of workflow dispatch