### PR TITLE
fix: resolve GitHub Advanced Security code scanning alerts

### DIFF
--- a/src/coldpack/cli.py
+++ b/src/coldpack/cli.py
@@ -1217,9 +1217,6 @@ def display_metadata_info(archive_path: Path, metadata: Any) -> None:
     # Check for related files and show their status
     related_files = []
     archive_dir = archive_path.parent
-    archive_name = archive_path.stem
-    if archive_name.endswith(".tar"):
-        archive_name = archive_name[:-4]  # Remove .tar from .tar.zst
 
     # Check for hash files
     sha256_file = archive_dir / f"{archive_path.name}.sha256"

--- a/src/coldpack/config/settings.py
+++ b/src/coldpack/config/settings.py
@@ -30,6 +30,7 @@ else:
 
         HAS_TOMLLIB = True
     except ImportError:
+        # tomli not available, will fall back to using TOML parsing via other means
         pass
 
 

--- a/src/coldpack/utils/hashing.py
+++ b/src/coldpack/utils/hashing.py
@@ -197,6 +197,7 @@ def generate_hash_files(
                 if hash_file.exists():
                     hash_file.unlink()
             except OSError:
+                # Ignore cleanup failures, main error will be raised above
                 pass
 
         raise HashingError(f"Failed to generate hash files: {e}") from e


### PR DESCRIPTION
## Summary
- Fixed unused local variable in CLI display function
- Added explanatory comments for empty except clauses to improve code clarity
- All changes maintain existing functionality while addressing GitHub Advanced Security recommendations

## Changes Made
- **cli.py**: Removed unused `archive_name` variable that was defined but never used
- **settings.py**: Added explanatory comment for empty except clause in tomli import fallback
- **hashing.py**: Added explanatory comment for empty except clause in cleanup error handling

## Test Plan
- [x] All existing tests pass (134/134)
- [x] Ruff code style checks pass
- [x] MyPy type checking passes  
- [x] CI workflow passes on GitHub
- [x] No functional changes - all modifications are code quality improvements

## Security Impact
These changes address GitHub Advanced Security recommendations while maintaining backward compatibility and existing functionality.