### PR TITLE
feat(archiver): show source content size in compression log

### DIFF
--- a/src/coldpack/core/archiver.py
+++ b/src/coldpack/core/archiver.py
@@ -414,7 +414,7 @@ class ColdStorageArchiver:
         source_size = sum(
             f.stat().st_size for f in source_dir.rglob("*") if f.is_file()
         )
-        logger.debug(f"Compressing {format_file_size(source_size)} of content")
+        logger.info(f"Source content size: {format_file_size(source_size)}")
 
         # Check if settings are manually configured
         if self.sevenzip_settings.manual_settings:
@@ -424,7 +424,7 @@ class ColdStorageArchiver:
                 if self.sevenzip_settings.threads == 0
                 else str(self.sevenzip_settings.threads)
             )
-            logger.debug(
+            logger.info(
                 f"Using manual 7z settings: level={self.sevenzip_settings.level}, "
                 f"dict={self.sevenzip_settings.dictionary_size}, threads={threads_display}"
             )


### PR DESCRIPTION
## Summary

This PR improves user experience by displaying source content size in the compression log, providing users with essential information for parameter selection and processing time estimation.

### Changes Made
- Display source content size before showing compression parameters
- Change manual settings log from debug to info level for consistency  
- Improve log message clarity with better formatting

### Problem Solved
Addresses two key user experience issues:
1. **Parameter Selection**: Users lacked reference data for making informed custom parameter decisions
2. **Time Estimation**: Users couldn't estimate processing time without knowing source size

### Example Output
**Before:**
```
Step 2: Creating 7z archive with dynamic optimization
Optimized 7z settings: level=9, dict=512m, threads=all
```

**After:**
```
Step 2: Creating 7z archive with dynamic optimization
Source content size: 17.02 GB
Optimized 7z settings: level=9, dict=512m, threads=all
```

### Benefits
- **Better UX**: Users can now see the actual content size being processed
- **Informed Decisions**: Size information helps users understand auto-optimization choices
- **Time Estimation**: Large files (like 17GB) help users set proper expectations
- **Consistency**: Both auto and manual settings now use info-level logging

## Test Plan
- [x] Tested with small files (248 bytes → level=1, dict=128k)
- [x] Tested with medium files (55KB → level=1, dict=128k) 
- [x] Tested with large files (17GB → level=9, dict=512m)
- [x] Verified log formatting and clarity
- [x] Passed ruff formatting and type checking