### PR TITLE
fix: update version validation regex to support PEP 440 compliant formats

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,9 +134,9 @@ jobs:
           local version="$1"
           local version_type="$2"
 
-          # Simplified regex patterns for better readability
-          local git_tag_pattern="^v[0-9]+\.[0-9]+\.[0-9]+(\.(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+))?$"
-          local generated_version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(\.(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+))?(-[0-9]+-g[0-9a-f]+)?$"
+          # PEP 440 compliant regex patterns (allow both v1.0.0rc1 and v1.0.0.rc1)
+          local git_tag_pattern="^v[0-9]+\.[0-9]+\.[0-9]+(\.?(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+))?$"
+          local generated_version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(\.?(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+))?(-[0-9]+-g[0-9a-f]+)?$"
 
           if [[ "$version_type" == "git_tag" ]]; then
             if [[ $version =~ $git_tag_pattern ]]; then
@@ -144,13 +144,13 @@ jobs:
               return 0
             else
               echo "✗ Invalid git tag format: $version"
-              echo "Expected format: v{major}.{minor}.{patch}[.{dev|a|b|rc}{N}]"
+              echo "Expected format: v{major}.{minor}.{patch}[{dev|a|b|rc}{N}] (PEP 440 compliant)"
               echo "Valid examples:"
               echo "  - Stable: v1.0.0, v2.1.3"
-              echo "  - Development: v1.0.0.dev1, v1.2.0.dev5"
-              echo "  - Alpha: v1.0.0.a1, v1.0.0.a2"
-              echo "  - Beta: v1.0.0.b1, v1.0.0.b2"
-              echo "  - Release Candidate: v1.0.0.rc1, v1.0.0.rc2"
+              echo "  - Development: v1.0.0dev1, v1.0.0.dev1"
+              echo "  - Alpha: v1.0.0a1, v1.0.0.a1"
+              echo "  - Beta: v1.0.0b1, v1.0.0.b1"
+              echo "  - Release Candidate: v1.0.0rc1, v1.0.0.rc1"
               return 1
             fi
           elif [[ "$version_type" == "generated" ]]; then
@@ -159,11 +159,11 @@ jobs:
               return 0
             else
               echo "✗ Invalid generated version format: $version"
-              echo "Expected format: {major}.{minor}.{patch}[.{dev|a|b|rc}{N}][-{commits}-g{hash}]"
+              echo "Expected format: {major}.{minor}.{patch}[{dev|a|b|rc}{N}][-{commits}-g{hash}] (PEP 440 compliant)"
               echo "Valid examples:"
               echo "  - Stable: 1.0.0, 2.1.3"
-              echo "  - Development: 1.0.0.dev1, 1.2.0.dev5"
-              echo "  - With git suffix: 1.0.0-5-g1a2b3c4, 1.0.0.dev1-2-g5d6e7f8"
+              echo "  - Development: 1.0.0dev1, 1.0.0.dev1"
+              echo "  - With git suffix: 1.0.0-5-g1a2b3c4, 1.0.0dev1-2-g5d6e7f8"
               return 1
             fi
           fi
@@ -227,9 +227,9 @@ jobs:
           local version="$1"
           local version_type="$2"
 
-          # Simplified regex patterns for better readability
-          local git_tag_pattern="^v[0-9]+\.[0-9]+\.[0-9]+(\.(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+))?$"
-          local generated_version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(\.(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+))?(-[0-9]+-g[0-9a-f]+)?$"
+          # PEP 440 compliant regex patterns (allow both v1.0.0rc1 and v1.0.0.rc1)
+          local git_tag_pattern="^v[0-9]+\.[0-9]+\.[0-9]+(\.?(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+))?$"
+          local generated_version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(\.?(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+))?(-[0-9]+-g[0-9a-f]+)?$"
 
           if [[ "$version_type" == "git_tag" ]]; then
             if [[ $version =~ $git_tag_pattern ]]; then
@@ -237,13 +237,13 @@ jobs:
               return 0
             else
               echo "✗ Invalid git tag format: $version"
-              echo "Expected format: v{major}.{minor}.{patch}[.{dev|a|b|rc}{N}]"
+              echo "Expected format: v{major}.{minor}.{patch}[{dev|a|b|rc}{N}] (PEP 440 compliant)"
               echo "Valid examples:"
               echo "  - Stable: v1.0.0, v2.1.3"
-              echo "  - Development: v1.0.0.dev1, v1.2.0.dev5"
-              echo "  - Alpha: v1.0.0.a1, v1.0.0.a2"
-              echo "  - Beta: v1.0.0.b1, v1.0.0.b2"
-              echo "  - Release Candidate: v1.0.0.rc1, v1.0.0.rc2"
+              echo "  - Development: v1.0.0dev1, v1.0.0.dev1"
+              echo "  - Alpha: v1.0.0a1, v1.0.0.a1"
+              echo "  - Beta: v1.0.0b1, v1.0.0.b1"
+              echo "  - Release Candidate: v1.0.0rc1, v1.0.0.rc1"
               return 1
             fi
           elif [[ "$version_type" == "generated" ]]; then
@@ -252,11 +252,11 @@ jobs:
               return 0
             else
               echo "✗ Invalid generated version format: $version"
-              echo "Expected format: {major}.{minor}.{patch}[.{dev|a|b|rc}{N}][-{commits}-g{hash}]"
+              echo "Expected format: {major}.{minor}.{patch}[{dev|a|b|rc}{N}][-{commits}-g{hash}] (PEP 440 compliant)"
               echo "Valid examples:"
               echo "  - Stable: 1.0.0, 2.1.3"
-              echo "  - Development: 1.0.0.dev1, 1.2.0.dev5"
-              echo "  - With git suffix: 1.0.0-5-g1a2b3c4, 1.0.0.dev1-2-g5d6e7f8"
+              echo "  - Development: 1.0.0dev1, 1.0.0.dev1"
+              echo "  - With git suffix: 1.0.0-5-g1a2b3c4, 1.0.0dev1-2-g5d6e7f8"
               return 1
             fi
           fi
@@ -293,7 +293,7 @@ jobs:
           echo "  Git describe output: $(git describe --tags --match='v*')"
           echo ""
           echo "🔍 Troubleshooting:"
-          echo "  1. Verify git tag format follows PEP 440: v{major}.{minor}.{patch}[.{dev|a|b|rc}{N}]"
+          echo "  1. Verify git tag format follows PEP 440: v{major}.{minor}.{patch}[{dev|a|b|rc}{N}]"
           echo "  2. Check if hatch-vcs is properly configured in pyproject.toml"
           echo "  3. Ensure tag is properly annotated: git tag -a v1.0.0 -m 'Release v1.0.0'"
           echo "  4. Verify working directory is clean and matches tagged commit"


### PR DESCRIPTION
## Summary
- Fix version validation regex to support PEP 440 compliant formats (`v1.0.0rc1` and `v1.0.0.rc1`)
- Update error messages to reflect PEP 440 compliance standards
- Maintain backward compatibility with existing version formats
- Resolve validation rejection of `v0.3.1rc1` format

## Changes Made
- Updated regex patterns in both validation functions to make dot before pre-release suffix optional
- Modified error messages to show both supported formats in examples
- Added PEP 440 compliance notes to validation output

## Test Plan
- [x] Verify regex accepts both `v1.0.0rc1` and `v1.0.0.rc1` formats
- [x] Confirm backward compatibility with existing stable versions
- [x] Validate error messages provide clear guidance
- [x] Pre-commit hooks and CI checks pass

## Related Issues
Fixes validation error: "Invalid git tag format: v0.3.1rc1"