### PR TITLE
fix(build): enforce strict PEP 440 version validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,9 +134,9 @@ jobs:
           local version="$1"
           local version_type="$2"
 
-          # PEP 440 compliant regex patterns (allow both v1.0.0rc1 and v1.0.0.rc1)
-          local git_tag_pattern="^v[0-9]+\.[0-9]+\.[0-9]+(\.?(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+))?$"
-          local generated_version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(\.?(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+))?(-[0-9]+-g[0-9a-f]+)?$"
+          # PEP 440 compliant regex patterns (strict format only)
+          local git_tag_pattern="^v[0-9]+\.[0-9]+\.[0-9]+(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+)?$"
+          local generated_version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+)?(-[0-9]+-g[0-9a-f]+)?$"
 
           if [[ "$version_type" == "git_tag" ]]; then
             if [[ $version =~ $git_tag_pattern ]]; then
@@ -147,10 +147,10 @@ jobs:
               echo "Expected format: v{major}.{minor}.{patch}[{dev|a|b|rc}{N}] (PEP 440 compliant)"
               echo "Valid examples:"
               echo "  - Stable: v1.0.0, v2.1.3"
-              echo "  - Development: v1.0.0dev1, v1.0.0.dev1"
-              echo "  - Alpha: v1.0.0a1, v1.0.0.a1"
-              echo "  - Beta: v1.0.0b1, v1.0.0.b1"
-              echo "  - Release Candidate: v1.0.0rc1, v1.0.0.rc1"
+              echo "  - Development: v1.0.0dev1"
+              echo "  - Alpha: v1.0.0a1"
+              echo "  - Beta: v1.0.0b1"
+              echo "  - Release Candidate: v1.0.0rc1"
               return 1
             fi
           elif [[ "$version_type" == "generated" ]]; then
@@ -162,7 +162,7 @@ jobs:
               echo "Expected format: {major}.{minor}.{patch}[{dev|a|b|rc}{N}][-{commits}-g{hash}] (PEP 440 compliant)"
               echo "Valid examples:"
               echo "  - Stable: 1.0.0, 2.1.3"
-              echo "  - Development: 1.0.0dev1, 1.0.0.dev1"
+              echo "  - Development: 1.0.0dev1"
               echo "  - With git suffix: 1.0.0-5-g1a2b3c4, 1.0.0dev1-2-g5d6e7f8"
               return 1
             fi
@@ -227,9 +227,9 @@ jobs:
           local version="$1"
           local version_type="$2"
 
-          # PEP 440 compliant regex patterns (allow both v1.0.0rc1 and v1.0.0.rc1)
-          local git_tag_pattern="^v[0-9]+\.[0-9]+\.[0-9]+(\.?(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+))?$"
-          local generated_version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(\.?(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+))?(-[0-9]+-g[0-9a-f]+)?$"
+          # PEP 440 compliant regex patterns (strict format only)
+          local git_tag_pattern="^v[0-9]+\.[0-9]+\.[0-9]+(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+)?$"
+          local generated_version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+)?(-[0-9]+-g[0-9a-f]+)?$"
 
           if [[ "$version_type" == "git_tag" ]]; then
             if [[ $version =~ $git_tag_pattern ]]; then
@@ -240,10 +240,10 @@ jobs:
               echo "Expected format: v{major}.{minor}.{patch}[{dev|a|b|rc}{N}] (PEP 440 compliant)"
               echo "Valid examples:"
               echo "  - Stable: v1.0.0, v2.1.3"
-              echo "  - Development: v1.0.0dev1, v1.0.0.dev1"
-              echo "  - Alpha: v1.0.0a1, v1.0.0.a1"
-              echo "  - Beta: v1.0.0b1, v1.0.0.b1"
-              echo "  - Release Candidate: v1.0.0rc1, v1.0.0.rc1"
+              echo "  - Development: v1.0.0dev1"
+              echo "  - Alpha: v1.0.0a1"
+              echo "  - Beta: v1.0.0b1"
+              echo "  - Release Candidate: v1.0.0rc1"
               return 1
             fi
           elif [[ "$version_type" == "generated" ]]; then
@@ -255,7 +255,7 @@ jobs:
               echo "Expected format: {major}.{minor}.{patch}[{dev|a|b|rc}{N}][-{commits}-g{hash}] (PEP 440 compliant)"
               echo "Valid examples:"
               echo "  - Stable: 1.0.0, 2.1.3"
-              echo "  - Development: 1.0.0dev1, 1.0.0.dev1"
+              echo "  - Development: 1.0.0dev1"
               echo "  - With git suffix: 1.0.0-5-g1a2b3c4, 1.0.0dev1-2-g5d6e7f8"
               return 1
             fi
@@ -402,7 +402,7 @@ jobs:
         echo "  Git tag: $GIT_TAG"
         echo "  Expected PyPI version: $EXPECTED_VERSION"
         echo "  Current commit: $GITHUB_SHA"
-        echo "  Release type: $(if [[ "$GIT_TAG" =~ \.(dev|a|b|rc) ]]; then echo "pre-release"; else echo "stable"; fi)"
+        echo "  Release type: $(if [[ "$GIT_TAG" =~ (dev|a|b|rc)[0-9]+$ ]]; then echo "pre-release"; else echo "stable"; fi)"
 
         # Show environment context
         echo "🔧 Publish environment:"
@@ -453,7 +453,7 @@ jobs:
         echo "  PyPI version: $EXPECTED_VERSION"
         echo "  Wheel count: $WHEEL_COUNT"
         echo "  Package name: coldpack"
-        echo "  Release notes: $(if [[ "$GIT_TAG" =~ \.(dev|a) ]]; then echo "Generated automatically"; else echo "From release-drafter"; fi)"
+        echo "  Release notes: $(if [[ "$GIT_TAG" =~ (dev|a)[0-9]+$ ]]; then echo "Generated automatically"; else echo "From release-drafter"; fi)"
         echo ""
         echo "📦 Final artifact list:"
         ls -la dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2025-08-05
+
 ### Added
 - **SafeConsole System**: Intelligent Unicode-safe console wrapper with automatic terminal capability detection and fallback character mapping for improved cross-platform Unicode support
 
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Thread Parameter Handling**: Fixed py7zz multicore settings where threads=0 was incorrectly treated as single-thread instead of all cores
+- **Version Validation**: Corrected regex patterns to strictly enforce PEP 440 compliant formats (`v1.0.0rc1`) and removed support for non-standard formats (`v1.0.0.rc1`)
 - **CI Compatibility**: Improved test module imports and mypy configuration for better CI environment compatibility
 
 ## [0.3.0] - 2025-08-03
@@ -105,7 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Core Functionality**: Initial implementation of multi-format archive processing
 - **Verification System**: Basic integrity checking and PAR2 recovery infrastructure
 
-[Unreleased]: https://github.com/RxChi1d/coldpack/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/RxChi1d/coldpack/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/RxChi1d/coldpack/releases/tag/v0.3.1
 [0.3.0]: https://github.com/RxChi1d/coldpack/releases/tag/v0.3.0
 [0.2.0]: https://github.com/RxChi1d/coldpack/releases/tag/v0.2.0
 [0.2.0a2]: https://github.com/RxChi1d/coldpack/releases/tag/v0.2.0a2


### PR DESCRIPTION
## Summary

This PR enforces strict PEP 440 version validation in the build workflow by removing support for non-standard version formats and ensuring compliance with the official PEP 440 specification.

### Key Changes

- **Strict PEP 440 Compliance**: Remove support for non-standard formats like `v1.0.0.rc1`
- **Standard Format Only**: Accept only official PEP 440 formats like `v1.0.0rc1`
- **Updated Error Messages**: Show only compliant format examples in validation errors
- **Fixed Detection Logic**: Correct release type and notes generation patterns

### Technical Details

#### Regex Pattern Changes
- **Before**: `^v[0-9]+\.[0-9]+\.[0-9]+(\.?(dev|a|b|rc)[0-9]+)?$` (allowed both formats)
- **After**: `^v[0-9]+\.[0-9]+\.[0-9]+(dev|a|b|rc)[0-9]+)?$` (strict PEP 440 only)

#### Valid Version Formats (After)
- Stable: `v1.0.0`, `v2.1.3`
- Development: `v1.0.0dev1`
- Alpha: `v1.0.0a1` 
- Beta: `v1.0.0b1`
- Release Candidate: `v1.0.0rc1`

#### Invalid Formats (Removed)
- ~~`v1.0.0.dev1`~~ → Use `v1.0.0dev1`
- ~~`v1.0.0.a1`~~ → Use `v1.0.0a1`
- ~~`v1.0.0.b1`~~ → Use `v1.0.0b1`
- ~~`v1.0.0.rc1`~~ → Use `v1.0.0rc1`

### Breaking Changes

**Version Tag Format**: Non-standard formats with dots before pre-release identifiers are no longer supported.

- ❌ **No longer supported**: `v1.0.0.rc1`, `v1.0.0.a1`, `v1.0.0.b1`, `v1.0.0.dev1`
- ✅ **Use instead**: `v1.0.0rc1`, `v1.0.0a1`, `v1.0.0b1`, `v1.0.0dev1`

This aligns the project with official PEP 440 standards and prevents confusion about supported version formats.

### Impact

- **Build Workflow**: More precise version validation with clearer error messages
- **Release Process**: Enforces consistent versioning standards
- **Documentation**: Updated CHANGELOG to reflect the validation correction

### Test Plan

- [x] Pre-commit hooks pass
- [x] CI workflow passes
- [x] Version validation logic tested with corrected patterns
- [x] Error messages provide clear PEP 440 guidance

### Related Issues

Addresses version validation inconsistency where both standard (`v1.0.0rc1`) and non-standard (`v1.0.0.rc1`) formats were accepted, contrary to PEP 440 specification.