### PR TITLE
fix(ci): implement comprehensive PR auto-labeling and release notes categorization system

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+# Auto-labeling configuration based on file changes
+
+docs:
+  - changed-files:
+    - any-glob-to-any-file: ['**/*.md', 'docs/**/*', '*.rst', '*.txt']
+
+test:
+  - changed-files:
+    - any-glob-to-any-file: ['tests/**/*', '**/*test*', '**/*spec*']
+
+ci:
+  - changed-files:
+    - any-glob-to-any-file: ['.github/**/*', '*.yml', '*.yaml', 'Dockerfile*', '.dockerignore']
+
+build:
+  - changed-files:
+    - any-glob-to-any-file: ['pyproject.toml', 'setup.py', 'setup.cfg', 'requirements*.txt', 'Pipfile*', 'poetry.lock']
+
+dependencies:
+  - changed-files:
+    - any-glob-to-any-file: ['requirements*.txt', 'pyproject.toml', 'setup.py', 'poetry.lock', 'Pipfile.lock']

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -34,6 +34,9 @@ categories:
       - 'ci'
       - 'cd'
       - 'workflow'
+  - title: '↩️ Reverts'
+    labels:
+      - 'revert'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
@@ -84,9 +87,10 @@ autolabeler:
   - label: 'style'
     title:
       - '/^style(\(.+\))?: .+/'
+  - label: 'revert'
+    title:
+      - '/^revert(\(.+\))?: .+/'
 template: |
-  ## What's Changed
-
   $CHANGES
 
   ## Contributors

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,42 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+      - dependencies
+  categories:
+    - title: 🚀 Features
+      labels:
+        - feat
+        - feature
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - fix
+        - bug
+        - bugfix
+    - title: 📚 Documentation
+      labels:
+        - docs
+        - documentation
+    - title: ⚡ Performance
+      labels:
+        - perf
+        - performance
+    - title: 🔧 Maintenance
+      labels:
+        - chore
+        - maintenance
+        - refactor
+        - style
+    - title: 🧪 Testing
+      labels:
+        - test
+        - testing
+    - title: 🔄 CI/CD
+      labels:
+        - ci
+        - cd
+        - workflow
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,71 @@
+name: Auto Label PRs
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto Label PR
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true
+
+  conventional-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR based on title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const prNumber = context.payload.pull_request.number;
+
+            // Define label mappings for conventional commit types
+            const labelMap = {
+              'feat': 'feat',
+              'fix': 'fix',
+              'docs': 'docs',
+              'style': 'style',
+              'refactor': 'refactor',
+              'perf': 'perf',
+              'test': 'test',
+              'chore': 'chore',
+              'ci': 'ci',
+              'build': 'ci',
+              'revert': 'revert'
+            };
+
+            // Extract conventional commit type from title
+            const conventionalPattern = /^(\w+)(\(.+\))?: .+/;
+            const match = title.match(conventionalPattern);
+
+            if (match) {
+              const commitType = match[1];
+              const label = labelMap[commitType];
+
+              if (label) {
+                try {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    labels: [label]
+                  });
+                  console.log(`Added label "${label}" to PR #${prNumber}`);
+                } catch (error) {
+                  console.log(`Failed to add label: ${error.message}`);
+                }
+              }
+            } else {
+              console.log(`Title "${title}" doesn't match conventional commit pattern`);
+            }


### PR DESCRIPTION
## Summary
- Fix release notes categorization issue in stable releases
- Implement automatic PR labeling based on conventional commit titles
- Implement file-based automatic labeling for documentation, tests, and CI changes
- Update release-drafter configuration to support proper categorization

## Changes Made
- **Added**: `.github/workflows/auto-label.yml` - Automatic PR labeling workflow
- **Added**: `.github/labeler.yml` - File-based labeling configuration
- **Added**: `.github/release.yml` - GitHub releases configuration
- **Updated**: `.github/release-drafter.yml` - Enhanced categories and autolabeler rules

## Test Plan
- [x] Manually added correct labels to existing PRs (#46, #47, #48, #49, #50)
- [ ] Verify this PR automatically receives `ci` label
- [ ] Verify release-drafter generates properly categorized release notes
- [ ] Test automatic labeling functionality for future PRs

## Breaking Changes
None

## Related Issues
Fixes release notes categorization issue where stable releases show uncategorized PR list instead of grouped categories