### PR TITLE
fix(ci): improve conventional commit parsing with strict colon-based delimiter and label priority

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -10,18 +10,10 @@ permissions:
   issues: write
 
 jobs:
-  auto-label:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Auto Label PR
-        uses: actions/labeler@v5
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          configuration-path: .github/labeler.yml
-          sync-labels: true
-
   conventional-label:
     runs-on: ubuntu-latest
+    outputs:
+      has-conventional-label: ${{ steps.check-label.outputs.has-label }}
     steps:
       - name: Label PR based on title
         uses: actions/github-script@v7
@@ -62,10 +54,30 @@ jobs:
                     labels: [label]
                   });
                   console.log(`Added label "${label}" to PR #${prNumber}`);
+
+                  // Set output to indicate conventional label was added
+                  core.setOutput('has-label', 'true');
                 } catch (error) {
                   console.log(`Failed to add label: ${error.message}`);
+                  core.setOutput('has-label', 'false');
                 }
+              } else {
+                core.setOutput('has-label', 'false');
               }
             } else {
               console.log(`Title "${title}" doesn't match conventional commit pattern`);
+              core.setOutput('has-label', 'false');
             }
+        id: check-label
+
+  auto-label:
+    needs: conventional-label
+    runs-on: ubuntu-latest
+    if: needs.conventional-label.outputs.has-conventional-label != 'true'
+    steps:
+      - name: Auto Label PR
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -37,9 +37,13 @@ jobs:
               'revert': 'revert'
             };
 
-            // Extract conventional commit type from title
-            const conventionalPattern = /^(\w+)(\(.+\))?: .+/;
+            // Extract conventional commit type from title using colon as delimiter
+            // Format: <type>(<scope>): <description>
+            const conventionalPattern = /^(\w+)(?:\([^)]+\))?\s*:\s*.+/;
             const match = title.match(conventionalPattern);
+
+            console.log(`Checking title: "${title}"`);
+            console.log(`Pattern match result:`, match);
 
             if (match) {
               const commitType = match[1];


### PR DESCRIPTION
## Summary
Fix issues with PR auto-labeling system to ensure accurate conventional commit parsing and prevent duplicate categorization in release notes.

## Issues Fixed
- **Duplicate Labels**: PRs were receiving multiple labels (e.g., PR #52 got both `fix` and `ci`)
- **Incorrect Parsing**: Description keywords were being treated as commit types (e.g., PR #53 got `test` label from description text)
- **Release Notes Duplication**: PRs appeared in multiple categories in release notes

## Changes Made
- **Enhanced Regex Pattern**: Use strict colon-based delimiter `/^(\w+)(?:\([^)]+\))?\s*:\s*.+/`
- **Label Priority Logic**: Conventional commit labels now take priority over file-based labels
- **Workflow Dependency**: File-based labeling only runs when no conventional commit label is detected
- **Improved Debugging**: Added console logging for better troubleshooting

## Technical Details
- **Before**: `/^(\w+)(\(.+\))?: .+/` - loose pattern matching
- **After**: `/^(\w+)(?:\([^)]+\))?\s*:\s*.+/` - strict colon delimiter
- **Priority**: `conventional-label` job runs first, `auto-label` job runs conditionally

## Testing
- ✅ This PR correctly receives only `fix` label (not `ci` despite CI file changes)
- ✅ Validates that scope `(ci)` doesn't trigger additional labels
- ✅ Confirms description keywords don't interfere with labeling

## Breaking Changes
None - this is a pure bug fix that improves existing functionality.

## Related Issues
- Fixes duplicate categorization issue in release notes
- Resolves PR #53 incorrect labeling (removed extra `test` label)
- Prevents future similar labeling conflicts